### PR TITLE
firmware: unify teensy code. Integrate canbus + circular buffer

### DIFF
--- a/Firmware/payload/.gitignore
+++ b/Firmware/payload/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/Firmware/payload/README.md
+++ b/Firmware/payload/README.md
@@ -1,0 +1,19 @@
+# Unified Payload PlatformIO project
+TODO
+
+PIO: PlatformIO
+
+# Usage
+Requires
+* VSCode with PIO extension
+
+Open this folder in VSCode. Click on the PIO extension; in the top left corner you should see "Project Tasks". Select the peripheral whose binary you want to generate from the tasks and click _Build_. It will provide you with a path to a _.hex_ file. You should upload that to the teensy.
+
+If you are uploading to a Teensy connected directly to your computer, just press _Upload_.
+
+If you are uploading to a remote computer, it goes something like:
+```
+you@pc$ scp bleh.hex abloop@10.0.10.1:/tmp/
+abloop@remotepc$ teensy_loader_cli --mcu=TEENSY40 -s /tmp/bleh.hex
+abloop@remotepc$ picocom -b 115200 /dev/serial/by-id/usb-Teensyduino_USB_Serial_8601650-if00  # to watch printout
+```

--- a/Firmware/payload/include/README
+++ b/Firmware/payload/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/Firmware/payload/include/brake.hpp
+++ b/Firmware/payload/include/brake.hpp
@@ -1,0 +1,70 @@
+#ifndef BRAKE_HPP
+#define BRAKE_HPP
+
+#include "FlexCAN_T4.h"
+
+#include "utils.hpp"
+
+namespace brake_ns {
+enum STATE {
+	OFF    ,
+	ON     ,
+};
+
+struct brake_s {
+	/* I have no idea what type of break will actually be used.
+	 In this case, I have imagined a break whose stopping force is
+	 controlled by an analog pin. Something...pressure valve...something*/
+	NODE node = BRAKE;
+	STATE state = OFF;
+	uint8_t pin;  // analog pin to control stopping force
+	int force;    // stopping force value between 0-2^16
+};
+
+const int MIN = 0;        // in ADC units
+const int MAX = 65536-1;  // in ADC units
+const int THRESHOLD = 5;  // in ADC units
+
+enum CANBUS_ID {
+	/* Mapped CANBUS messages
+		At most 256 messages can be defined (0x00 - 0xFF).
+
+		For simplicity, we assume every ID is associated with a
+		4 byte payload for both RX and TX
+	*/
+	OK			= 0x00,  // Generic OK response
+	FAIL		= 0x01,  // Generic FAIL response
+	ACTIVATE	= 0x02,
+	DEACTIVATE	= 0x03,
+	READ_ADC	= 0x04,
+};
+
+STATE get_state(struct brake_s &);
+void activate(struct brake_s &);
+void deactivate(struct brake_s &);
+int get_value (struct brake_s &brake_s);
+FCTP_FUNC void canbus_payload_to_brake(struct brake_s &brake_s, CAN_message_t &msg, CANBus<_bus, _rxSize, _txSize> &can) {
+	/* Translate CANBus messages to brake commands */
+	CAN_message_t tx_msg;
+	int payload;
+	int_of_bytes(payload, msg.buf);  // always 4 bytes
+	switch (msg.id)
+	{
+	case (CAN_BRK_ID | ACTIVATE):
+		activate(brake_s);
+		data_to_canbus_payload(tx_msg, CAN_BRK_ID | OK, IGNORE_VALUE);
+		break;
+	case (CAN_BRK_ID | DEACTIVATE):
+		deactivate(brake_s);
+		data_to_canbus_payload(tx_msg, CAN_BRK_ID | OK, IGNORE_VALUE);
+		break;
+	case (CAN_BRK_ID | READ_ADC):
+		int adc_value = get_value(brake_s);
+		data_to_canbus_payload(tx_msg, CAN_BRK_ID | READ_ADC, adc_value);
+		break;
+	}
+	can.buffer_outgoing(tx_msg);
+}
+}
+
+#endif

--- a/Firmware/payload/include/node_stubs.hpp
+++ b/Firmware/payload/include/node_stubs.hpp
@@ -1,0 +1,21 @@
+#ifndef NODE_STUBS_HPP
+#define NODE_STUBS_HPP
+
+#include "brake.hpp"
+#include "utils.hpp"
+
+const int BMS_MIN_VOLTAGE = 10000;       // mVolts
+const int BMS_MAX_VOLTAGE = 12000;       // mVolts
+const int BMS_MIN_CURRENT = 100;         // mAmps
+const int BMS_MAX_CURRENT = 3000;        // mAmps
+const int BMS_MIN_TEMP = 15;             // Celcius
+const int BMS_MAX_TEMP = 40;             // Celcius
+const int BRAKE_MIN = 0;                 // in ADC units
+const int BRAKE_MAX = 65536-1;           // in ADC units
+
+void update_bms(struct bms &);
+// void update_brake(struct brake_s &);
+int stringify_bms(uint8_t* buffer, struct bms &_bms);
+void seed_random(int seed);
+
+#endif

--- a/Firmware/payload/include/utils.hpp
+++ b/Firmware/payload/include/utils.hpp
@@ -1,0 +1,141 @@
+#ifndef UTILS_HPP
+#define UTILS_HPP
+
+#include <stdint.h>
+
+#include <CircularBuffer.h>
+#include "FlexCAN_T4.h"
+
+#define IGNORE_VALUE 0
+
+void int_to_bytes(uint8_t*, const int);
+void int_of_bytes(int &, const uint8_t*);
+void print_buffer(const CAN_message_t &);
+
+void data_to_canbus_payload(CAN_message_t &, const uint32_t, const int);
+
+enum CAN_ID {
+	CAN_BMS_ID = 0x100,
+	CAN_NAV_ID = 0x200,
+	CAN_BRK_ID = 0x300,
+	CAN_MTR_ID = 0x400,
+	CAN_OBC_ID = 0x500,
+};
+
+enum NODE {
+	BMS,
+	NAV,
+	BRAKE,
+	MOTOR,
+	OBC
+};
+
+struct bms {
+	NODE node = BMS;
+	int voltage;
+	int current;
+	int temp;
+};
+
+struct navigation {
+	NODE node = NAV;
+};
+
+struct motor {
+	NODE node = MOTOR;
+};
+
+
+FCTP_CLASS class CANBus
+{
+	FlexCAN_T4<_bus, _rxSize, _txSize> &can;
+	CircularBuffer<CAN_message_t, 10> incoming_buffer;
+	CircularBuffer<CAN_message_t, 10> outgoing_buffer;
+public:
+	CANBus(FlexCAN_T4<_bus, _rxSize, _txSize> can_): can(can_) {}
+	// CANBus(FlexCAN_T4 *fc, CAN_filter_t *mask);
+	bool incoming_empty();
+	void clear_incoming();
+	uint8_t n_incoming_buffers();
+	bool outgoing_empty();
+	void clear_outgoing();
+	uint8_t n_outgoing_buffers();
+	bool buffer_incoming();
+	int read(CAN_message_t &);
+	bool buffer_outgoing(CAN_message_t &msg_out);
+	int send();
+};
+
+// CANBus::CANBus(FlexCAN_T4 *fc, CAN_filter_t *mask) {
+//     this->can = fc;
+//     if(mask == 0) {
+//         this->can->begin();
+//     } else {
+//         this->can->begin(*mask);
+//     }
+// }
+
+FCTP_FUNC bool CANBus<_bus, _rxSize, _txSize>::incoming_empty() {
+	return this->incoming_buffer.isEmpty();
+}
+
+FCTP_FUNC void CANBus<_bus, _rxSize, _txSize>::clear_incoming() {
+	this->incoming_buffer.clear();
+}
+
+FCTP_FUNC bool CANBus<_bus, _rxSize, _txSize>::outgoing_empty() {
+	return this->outgoing_buffer.isEmpty();
+}
+
+FCTP_FUNC void CANBus<_bus, _rxSize, _txSize>::clear_outgoing() {
+	this->outgoing_buffer.clear();
+}
+
+FCTP_FUNC uint8_t CANBus<_bus, _rxSize, _txSize>::n_incoming_buffers() {
+	return this->incoming_buffer.size();
+}
+
+FCTP_FUNC uint8_t CANBus<_bus, _rxSize, _txSize>::n_outgoing_buffers() {
+	return this->outgoing_buffer.size();
+}
+
+FCTP_FUNC bool CANBus<_bus, _rxSize, _txSize>::buffer_incoming() {
+	// pull message from CANBUS and write it to incoming buffer
+	CAN_message_t msg_in;
+	Serial.print("Buffer incoming received: ");
+	print_buffer(msg_in);
+	this->can.read(msg_in);
+	return this->incoming_buffer.unshift(msg_in);
+}
+
+FCTP_FUNC int CANBus<_bus, _rxSize, _txSize>::read(CAN_message_t &msg) {
+	// pull message from incoming buffer
+	if (!this->incoming_buffer.isEmpty()) {
+		CAN_message_t msg = this->incoming_buffer.pop();
+		Serial.print("Incoming buffer read: ");
+		print_buffer(msg);
+		return 0;
+	}
+	return -1;
+}
+
+FCTP_FUNC bool CANBus<_bus, _rxSize, _txSize>::buffer_outgoing(CAN_message_t &msg_out) {
+	// write message to outgoing buffer
+	Serial.print("Outgoing buffer received: ");
+	print_buffer(msg_out);
+	return this->outgoing_buffer.unshift(msg_out);
+}
+
+FCTP_FUNC int CANBus<_bus, _rxSize, _txSize>::send() {
+	// push message from outgoing buffer to CANBUS
+	if (!this->outgoing_buffer.isEmpty()) {
+		CAN_message_t msg_out = this->outgoing_buffer.pop();
+		Serial.print("Outgoing buffer sent: ");
+		print_buffer(msg_out);
+		this->can.write(msg_out);
+		return 0;
+	}
+	return -1;
+}
+
+#endif

--- a/Firmware/payload/lib/README
+++ b/Firmware/payload/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/Firmware/payload/platformio.ini
+++ b/Firmware/payload/platformio.ini
@@ -1,0 +1,37 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env]
+platform = teensy
+framework = arduino
+lib_deps =
+	gitlab-arduino-libraries/StensTimer@^1.1.2
+	rlogiacco/CircularBuffer@^1.3.3
+build_flags =
+	-D VERSION=0.0.1
+
+[env:bms]
+board = teensy40
+build_flags =
+	${env.build_flags}
+	-DPERIPHERAL_BMS
+
+[env:brake]
+board = teensy40
+build_flags =
+	${env.build_flags}
+	-DPERIPHERAL_BRAKE
+
+[env:brakeandobc]
+board = teensy40
+build_flags =
+	${env.build_flags}
+	-DPERIPHERAL_BRAKE
+	-DSIMULATE_OBC

--- a/Firmware/payload/src/bms.cpp
+++ b/Firmware/payload/src/bms.cpp
@@ -1,0 +1,8 @@
+#include <FlexCAN_T4.h>
+
+#include "utils.hpp"
+
+void prepare_bms_message(struct bms &_bms, CAN_message_t &msg) {
+  int_to_bytes(msg.buf, _bms.current);
+  int_to_bytes(&msg.buf[4], _bms.voltage);
+}

--- a/Firmware/payload/src/brake.cpp
+++ b/Firmware/payload/src/brake.cpp
@@ -1,0 +1,33 @@
+#include "Arduino.h"
+#include "FlexCAN_T4.h"
+
+#include "brake.hpp"
+#include "utils.hpp"
+
+namespace brake_ns {
+STATE get_state(struct brake_s &brake_s) {
+	return brake_s.state;
+}
+
+int get_value (struct brake_s &brake_s) {
+	return analogRead(brake_s.pin);
+}
+
+void set(struct brake_s &brake_s, int force) {
+	analogWrite(brake_s.pin, force);
+	if (force > THRESHOLD)
+		brake_s.state = ON;
+	else
+		brake_s.state = OFF;
+}
+
+void activate(struct brake_s &brake_s) {
+	if (brake_s.state == OFF)
+		set(brake_s, MAX);
+}
+
+void deactivate(struct brake_s &brake_s) {
+	if (brake_s.state == ON)
+		set(brake_s, MIN);
+}
+};

--- a/Firmware/payload/src/main.cpp
+++ b/Firmware/payload/src/main.cpp
@@ -1,0 +1,66 @@
+#include <FlexCAN_T4.h>
+#include <StensTimer.h>
+
+#include "brake.hpp"
+#include "node_stubs.hpp"  // For simulating
+#include "utils.hpp"
+
+FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_16> can1;
+FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_16> can2;  // Only used to simulate OBC
+brake_ns::brake_s brake_s_;
+CANBus<CAN1, RX_SIZE_256, TX_SIZE_16> can(can1);
+CANBus<CAN2, RX_SIZE_256, TX_SIZE_16> obc_can(can2);
+#define FAKE_OBC_MESSAGE 1  // Action
+#define FAKE_OBC_MESSAGE_MS 1000  // Time between actions in milliseconds
+StensTimer* timer;
+
+void timer_callback(Timer* timer){
+	Serial.print("Timer call -> Action: ");
+	Serial.print(timer->getAction());
+	Serial.print(", Current Time: ");
+	Serial.println(millis());
+	if (timer->getAction() == FAKE_OBC_MESSAGE) {
+		CAN_message_t fake_msg;
+		fake_msg.id = CAN_BRK_ID | brake_ns::ACTIVATE;
+		int_to_bytes(fake_msg.buf, IGNORE_VALUE);
+		if (!obc_can.buffer_outgoing(fake_msg))
+		{
+			Serial.println("Outgoing buffer failed to queue msg");
+		};
+	};
+}
+
+void setup(void) {
+	Serial.println("Setting up");
+	can1.begin();
+	can1.setBaudRate(250000);
+	seed_random(analogRead(0));
+	#ifdef SIMULATE_OBC
+	Serial.println("Simulating OBC");
+	timer = StensTimer::getInstance();
+	timer->setStaticCallback(timer_callback);
+	timer->setInterval(FAKE_OBC_MESSAGE, FAKE_OBC_MESSAGE_MS);
+	#endif
+	Serial.println("Setup completed");
+}
+
+void loop() {
+	if (!can.incoming_empty())
+	{
+		#ifdef PERIPHERAL_BRAKE
+		static CAN_message_t msg;
+		can.read(msg);
+		brake_ns::canbus_payload_to_brake(brake_s_, msg, can);
+		#endif
+	}
+	if (!can.outgoing_empty()) {
+		Serial.print("Peripheral outgoing buffers: ");
+		Serial.println(can.n_outgoing_buffers());
+		can.send();
+	}
+	#ifdef SIMULATE_OBC
+	timer->run();
+	// This keeps bricking the Teensy...
+	obc_can.send();
+	#endif
+}

--- a/Firmware/payload/src/node_stubs.cpp
+++ b/Firmware/payload/src/node_stubs.cpp
@@ -1,0 +1,31 @@
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+
+#include "brake.hpp"
+#include "node_stubs.hpp"
+#include "utils.hpp"
+
+bool seeded = false;
+#define get_bounded_random_number(min, max) ((rand()%(int)(((max) + 1)-(min)))+ (min))
+
+void update_bms(struct bms &_bms) {
+	_bms.voltage = get_bounded_random_number(BMS_MIN_VOLTAGE, BMS_MAX_VOLTAGE);
+	_bms.current = get_bounded_random_number(BMS_MIN_CURRENT, BMS_MAX_CURRENT);
+	_bms.temp = get_bounded_random_number(BMS_MIN_TEMP, BMS_MAX_TEMP);
+}
+
+// void update_brakes(struct brake_ns::brake &_brake) {
+// 	_brake.value = get_bounded_random_number(BRAKE_MIN, BRAKE_MAX);
+// }
+
+int stringify_bms(uint8_t* buffer, struct bms &_bms) {
+	return sprintf((char *) buffer, "BMS Voltage: %d. Current: %d. Temperature: %d", _bms.voltage, _bms.current, _bms.temp);
+}
+
+void seed_random(int seed) {
+	if (!seeded) {
+		srand((unsigned) seed);
+		seeded = true;
+	}
+}

--- a/Firmware/payload/src/obc.cpp
+++ b/Firmware/payload/src/obc.cpp
@@ -1,0 +1,26 @@
+#include "Arduino.h"
+
+#include "FlexCAN_T4.h"
+
+#include "utils.hpp"
+
+namespace obc {
+/* On Board Computer */
+enum TRANSITION {
+  START  ,
+  STOP   ,
+};
+struct command {
+  TRANSITION transition;
+  uint8_t* value;
+};
+enum STATE {
+  SAFE,         // Default state. Pod is on, not moving and safe for approach
+  READY,        // Ready to launch - not accelerating
+  LAUNCHING,    // Commanding propulsion for highest velocity
+  COASTING,     // Moving at a constant velocity
+  BRAKING,      // Decelerating with brake
+  CRAWLING,     // Commading propulsion for not highest velocity (??)
+  FAULT,        // Something went wrong
+};
+}

--- a/Firmware/payload/src/utils.cpp
+++ b/Firmware/payload/src/utils.cpp
@@ -1,0 +1,44 @@
+#include <cstring>
+#include <stdint.h>
+
+#include "FlexCAN_T4.h"
+
+#include "utils.hpp"
+
+void int_to_bytes(uint8_t* a, const int i) {
+	/* Convert 32-bit integer "i" to a four byte, little endian array "a"
+
+		Example: 1234567890, which is 01001001 10010110 00000010 11010010
+		returns [11010010, 00000010, 10010110, 01001001]
+
+		Another way to potentially do this (does not work as is)
+		a = static_cast<uint8_t*>(static_cast<void*>(&i));
+	*/
+	a[0] = (i & 0x000000ff);
+	a[1] = (i & 0x0000ff00) >> 8;
+	a[2] = (i & 0x00ff0000) >> 16;
+	a[3] = (i & 0xff000000) >> 24;
+}
+
+void int_of_bytes(int &i, const uint8_t* a) {
+	/* Convert little-endian byte array to integer */
+	memcpy(&i, a, sizeof(i));
+}
+
+void print_buffer(const CAN_message_t &msg) {
+	/* Example printout (6 bytes):
+		ID: 100 Buffer: A 2 0 0 31 2D
+	*/
+	Serial.print(" ID: "); Serial.print(msg.id, HEX);
+	Serial.print(" Buffer: ");
+	for ( uint8_t i = 0; i < msg.len; i++ ) {
+	  Serial.print(msg.buf[i], HEX); Serial.print(" ");
+	} Serial.println();
+}
+
+void data_to_canbus_payload(CAN_message_t &msg, const uint32_t id, const int value) {
+	/* Encodes a four-byte payload to msg for sending over CANBUS */
+	msg.id = id;
+	msg.len = 4;
+	int_to_bytes(msg.buf, value);
+}

--- a/Firmware/payload/test/README
+++ b/Firmware/payload/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Unit Testing and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/page/plus/unit-testing.html


### PR DESCRIPTION
# Summary
Init a generic structure for all Teensy-based peripherals to be built off of. The benefits:
* everything is in one PlatformIO project, which keeps includes simple
* can compile individual binaries for each Teensy with the click of a button in VSCode
* provides a template for writing & handling CANBus messages

# Test
Currently, a Teensy4.0 bricks on main.cpp:line 64. To do...