### PR TITLE
CI: Init automated build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  platformio:
+    runs-on: ubuntu-latest
+    container: infinitecoding/platformio-for-ci:latest
+
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Build
+          run: platformio run -d ./Firmware/canbus_one_teensy_two_nodes/
+
+        - name: Test
+          run: echo "This is a test"
+
+        - name: Upload
+          uses: actions/upload-artifact@v2
+          with:
+            name: firmware.hex
+            path: Firmware/canbus_one_teensy_two_nodes/.pio/build/teensy40/firmware.hex


### PR DESCRIPTION
# Summary
Init automated build. Builds the hex file for a CANBus test program using a pio container. This will be useful when we add programs that we want others to use. Instead of saying "build this on your computer" we can say "go to this link, download the file and install it".
* CI: Init main.yml

The artifact is poorly named. It should be <program name>, not something as generic as "firmware". Will address later.

mentions #14 

# Test
1. Downloaded the artifact from the [action page](https://github.com/albertaloop/T_SWE_2019_2020/actions/runs/1804583638)
2. unzipped and `scp ~/Downloads/firmware.hex abloop@<my beaglebone IP>:/tmp/`
3. ssh into beaglebone `ssh abloop@<my beaglebone IP>`
4. upload firmware `abloop$ teensy /tmp/firmware.hex`
5. check printout `picocom -b 115200 /dev/serial/by-id/usb-Teensyduino_USB_Serial_8601650-if00`